### PR TITLE
Реализация retry для tap() Gemz

### DIFF
--- a/app/services/GemzGameService.ts
+++ b/app/services/GemzGameService.ts
@@ -205,7 +205,9 @@ export default class GemzGameService
                     });
 
                     await sleep(0.3 * Math.pow(2, attemptCount - 1) * 1000);
-                    replicateError = await replicateTaps().then(() => false).catch(() => true);
+                    replicateError = await replicateTaps()
+                        .then(() => false)
+                        .catch(() => true);
 
                     if (!replicateError) {
                         break;

--- a/app/services/GemzGameService.ts
+++ b/app/services/GemzGameService.ts
@@ -182,8 +182,8 @@ export default class GemzGameService
         await this.httpClient.post('loginOrCreate');
     }
 
-    public async tap(quantity: number = 1): Promise<void> {
-        let attemptCount: number = 1;
+    public async tap(quantity: number = 1, attemptCount: number = 0): Promise<void> {
+        attemptCount++;
 
         await this.replicate(this.generateTaps(quantity)).catch(async (error: HTTPError) => {
             const response: IReplicationError | any = await error.response.json();
@@ -196,7 +196,6 @@ export default class GemzGameService
 
                 if (attemptCount < 3) {
                     await sleep(0.3 * 2 ** (attemptCount - 1) * 1000);
-                    attemptCount++;
                     return this.tap(quantity);
                 }
 

--- a/app/services/GemzGameService.ts
+++ b/app/services/GemzGameService.ts
@@ -195,7 +195,7 @@ export default class GemzGameService
                 });
 
                 if (attemptCount < 3) {
-                    await sleep(0.3 * (2 ** (attemptCount++ - 1)) * 1000);
+                    await sleep(0.3 * 2 ** (attemptCount++ - 1) * 1000);
                     return this.tap(quantity);
                 }
 

--- a/app/services/GemzGameService.ts
+++ b/app/services/GemzGameService.ts
@@ -195,7 +195,8 @@ export default class GemzGameService
                 });
 
                 if (attemptCount < 3) {
-                    await sleep(0.3 * 2 ** (attemptCount++ - 1) * 1000);
+                    await sleep(0.3 * 2 ** (attemptCount - 1) * 1000);
+                    attemptCount++;
                     return this.tap(quantity);
                 }
 

--- a/helpers/timer.ts
+++ b/helpers/timer.ts
@@ -1,0 +1,1 @@
+export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/helpers/timer.ts
+++ b/helpers/timer.ts
@@ -1,6 +1,12 @@
+/**
+ * Функция ожидания заданного времени в миллисекундах
+ *
+ * @param ms Время ожидания в миллисекундах
+ * @returns Promise<void>
+ */
 export const sleep = (ms: number) => {
-    if (ms < 0) {
-        throw new TypeError('ms должен быть положительным');
+    if (!Number.isInteger(ms) || ms < 0) {
+        throw new TypeError('ms должен быть положительным целым числом');
     }
 
     return new Promise((resolve) => setTimeout(resolve, ms));

--- a/helpers/timer.ts
+++ b/helpers/timer.ts
@@ -1,1 +1,7 @@
-export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+export const sleep = (ms: number) => {
+    if (ms < 0) {
+        throw new TypeError('ms должен быть положительным');
+    }
+
+    return new Promise((resolve) => setTimeout(resolve, ms));
+};


### PR DESCRIPTION
Попытка повторить запрос 3 раза, если поймал `replication_error`

Не получилось сделать через retry от библиотеки ky, потому-что там нельзя менять запрос. Сделал рекурсию с условием выхода до 3х попыток.

Добавил sleep() хелпер и умный backoff, который рассчитывается на основе текущей попытки, экспоненциально поднимая ожидание для следующей отправки.

Сейчас в случае ошибки он со второго раза всегда срабатывает нормально, ошибок не кидает 👍

Пример вывода уровня debug
```
app-1    | [20:05:16.236] DEBUG (5291):
app-1    |     replicationError: {
app-1    |       "message": "55cb7c72-dbdd-4f43-bfb4-a4053fd4735d",
app-1    |       "code": "replication_error",
app-1    |       "subCode": "client_time_invalid"
app-1    |     }
app-1    |     attemptCount: 1
```