### PR TITLE
Добавлен GET метод на получение статистики онлайн пользователей

### DIFF
--- a/adonisrc.ts
+++ b/adonisrc.ts
@@ -82,7 +82,7 @@ export default defineConfig({
     | List of modules to import before starting the application.
     |
     */
-    preloads: [() => import('#start/kernel'), () => import('#start/events')],
+    preloads: [() => import('#start/kernel'), () => import('#start/events'), () => import('#start/routes')],
 
     /*
     |--------------------------------------------------------------------------

--- a/app/controllers/StatisticController.ts
+++ b/app/controllers/StatisticController.ts
@@ -1,0 +1,16 @@
+import { RedisService } from '@adonisjs/redis/types';
+import app from '@adonisjs/core/services/app';
+
+export default class CartItemsController {
+    async getOnlineUsers() {
+        const redis: RedisService = await app.container.make('redis');
+
+        const activeUsersCount: number = (await redis.keys('user:*')).length;
+
+        return {
+            data: {
+                onlineUsers: activeUsersCount,
+            },
+        };
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,9 @@ services:
             KEY_GENERATE_PROXY_USER: '${KEY_GENERATE_PROXY_USER:-}'
             KEY_GENERATE_PROXY_PASSWORD: '${KEY_GENERATE_PROXY_PASSWORD:-}'
 
+        ports:
+            - '${PORT:-80}:80'
+
         depends_on:
             redis:
                 condition: service_healthy
@@ -41,10 +44,7 @@ services:
         volumes:
             - 'redis-data:/data'
         healthcheck:
-            test:
-                - CMD
-                - redis-cli
-                - ping
+            test: ['CMD', 'redis-cli', 'ping']
             retries: 3
             timeout: 5s
 

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -1,0 +1,5 @@
+import router from '@adonisjs/core/services/router';
+
+const StatisticController = () => import('#controllers/StatisticController');
+
+router.get('/statistic/online-users', [StatisticController, 'getOnlineUsers']);


### PR DESCRIPTION
Добавлен эндпоинт на получение количества активных пользователей

```bash
curl 'http://127.0.0.1:3333/statistic/online-users'
```

```json
{
    "data" : {
        "onlineUsers": 2
    }
}
```